### PR TITLE
Update CVE-2024-27198.json

### DIFF
--- a/2024/CVE-2024-27198.json
+++ b/2024/CVE-2024-27198.json
@@ -42,12 +42,6 @@
 			"source": "Github",
 			"url": "https://github.com/Stuub/RCity-CVE-2024-27198",
 			"time_stamp": "2024-04-22T22:14:24Z"
-		},
-		{
-			"type": "exploit",
-			"source": "Github",
-			"url": "https://github.com/Pypi-Project/RCity-CVE-2024-27198",
-			"time_stamp": "2024-08-12T04:46:34Z"
 		}
 	]
 }


### PR DESCRIPTION
One malicious Poc project: https://github.com/Pypi-Project/RCity-CVE-2024-27198 was removed
Analysis and screenshots from my post: https://x.com/AabyssZG/status/1823247212119519517